### PR TITLE
Sopel 8 readiness pass

### DIFF
--- a/sopel_8ball/choices.py
+++ b/sopel_8ball/choices.py
@@ -7,7 +7,7 @@ from typing import Tuple
 
 from sopel.bot import Sopel  # type: ignore
 from sopel.config import Config  # type: ignore
-from sopel.tools.target import Identifier  # type: ignore
+from sopel.tools import Identifier  # type: ignore
 
 
 class AbstractChoiceProvider(abc.ABC):


### PR DESCRIPTION
Sopel's `Identifier` type doesn't live in `sopel.tools.target`. This import worked in Sopel 7, but [will break in v8](https://github.com/sopel-irc/sopel/commit/04d20a2df3450d61c90bd2b02e615055e5357778). As it's for type checking only, importing from `sopel.tools` should be fine; that won't change.

Also I noticed the docstring [here](https://github.com/Exirel/sopel-8ball/blob/161dc277672d71d7cbd34dc13f0c071175089c27/sopel_8ball/choices.py#L47-L54) doesn't match the actual method arguments, but didn't quite know what to put there instead so I didn't rewrite it.