### PR TITLE
choices: add Weeaball provider

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -43,6 +43,7 @@ sopel_8ball.choices =
     classic = sopel_8ball.choices:Classic
     snarky = sopel_8ball.choices:Snarky
     spooky = sopel_8ball.choices:Spooky
+    weeaball = sopel_8ball.choices:Weeaball
 
 [flake8]
 max-line-length = 79

--- a/sopel_8ball/choices.py
+++ b/sopel_8ball/choices.py
@@ -152,3 +152,38 @@ class Spooky(AbstractChoiceProvider):
             "Hidden and fathomless minds pulsate in rage.",
             "The underworld grumbles with repudiation.",
         )
+
+
+class Weeaball(AbstractChoiceProvider):
+    """A weeaboo magic 8 ball."""
+    def choices(self) -> Tuple[str, ...]:
+        return (
+            # affirmative answers
+            "Atarimae. (＾▽＾)",
+            "Daijoubu~ ٩(◕‿◕｡)۶",
+            "Hai! (⌒‿⌒)",
+            "Ii kangae! (ﾉ◕ヮ◕)ﾉ*:･ﾟ✧",
+            "Mochiron. (*￣▽￣)b",
+            "Sou desu. (٥⁀▽⁀ )b",
+            "Zettai! ＼(＾▽＾)／",
+
+            # non-committal answers
+            "Betsu ni. ╮(︶︿︶)╭",
+            "Isogashii… (－ω－) zzZ",
+            "Ittai dou iu imi desu ka?! ლ(ಠ_ಠ ლ)",
+            "Katte ni shiro! (ノ°益°)ノ",
+            "Mendokusai. (＃￣0￣)",
+            "Omae kankei nai. (ಠ_ಠ)",
+            "Osoraku. ┐(°ヮ°)┌",
+            "Tsumaranai. ┐( ˘ ､ ˘ )┌",
+            "Urusai! (╬`益´)",
+
+            # negative answers
+            "Arienai. (|||❛︵❛。)"
+            "Chigau. (◞ ‸ ◟ㆀ)",
+            "Dame! o(╥﹏╥)",
+            "Iie. (ᗒᗩᗕ)",
+            "Masaka! (╯︵╰)",
+            "Muri. ▄█▀█●",
+            "Zannen. _|￣|○",
+        )

--- a/tests/test_choices.py
+++ b/tests/test_choices.py
@@ -1,7 +1,8 @@
 """Test ``sopel_8ball.choices``."""
 from __future__ import generator_stop
 
-from sopel_8ball.choices import AbstractChoiceProvider, Classic, Snarky, Spooky
+from sopel_8ball.choices import (
+    AbstractChoiceProvider, Classic, Snarky, Spooky, Weeaball)
 
 
 def test_abstract_provider():
@@ -34,4 +35,12 @@ def test_spooky():
     choices = provider.choices()
 
     assert len(choices) == 20
+    assert provider.query(None, None) in choices
+
+
+def test_weeaball():
+    provider = Weeaball()
+    choices = provider.choices()
+
+    assert len(choices) == 22
     assert provider.query(None, None) in choices

--- a/tests/test_managers.py
+++ b/tests/test_managers.py
@@ -8,7 +8,8 @@ def test_manager_provider_names():
     assert managers.manager.provider_names == (
         'classic',
         'snarky',
-        "spooky",
+        'spooky',
+        'weeaball',
     )
 
 
@@ -91,3 +92,25 @@ def test_manager_setup_spooky(configfactory, botfactory):
     manager.setup(mockbot)
 
     assert isinstance(manager.provider, choices.Spooky)
+
+
+TMP_CONFIG_WEEABALL = """
+[core]
+owner = testnick
+nick = TestBot
+enable = coretasks, 8ball
+
+[magic8ball]
+choices = weeaball
+"""
+
+
+def test_manager_setup_weeaball(configfactory, botfactory):
+    manager = managers.Manager()
+    tmpconfig = configfactory('test.cfg', TMP_CONFIG_WEEABALL)
+    mockbot = botfactory(tmpconfig)
+
+    tmpconfig.define_section('magic8ball', config.Magic8ballSection)
+    manager.setup(mockbot)
+
+    assert isinstance(manager.provider, choices.Weeaball)


### PR DESCRIPTION
Weeb answers for anime fans. Comes complete with kaomoji. Name suggestion by @SnoopJ on IRC.

I started with about 30 answers, and deleted several that didn't feel like a good fit any more while looking for kaomoji. Wouldn't mind eliminating 2 more if you want to target 20 responses for each choice provider, but I am tired of rebalancing the three types of response. Been at this for over an hour, and it's break time. (❁ᴗ͈ ˬ ᴗ͈)ᶻᶻᶻ✧