### PR TITLE
choices: add YesNo provider

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,7 @@ classic = "sopel_8ball.choices:Classic"
 snarky = "sopel_8ball.choices:Snarky"
 spooky = "sopel_8ball.choices:Spooky"
 weeaball = "sopel_8ball.choices:Weeaball"
+yesno = "sopel_8ball.choices:YesNo"
 
 [dependency-groups]
 dev = [ # These are requirements to develop the plugin itself.

--- a/sopel_8ball/choices.py
+++ b/sopel_8ball/choices.py
@@ -192,3 +192,11 @@ class Weeaball(AbstractChoiceProvider):
             "Muri. ▄█▀█●",
             "Zannen. _|￣|○",
         )
+
+
+class YesNo(AbstractChoiceProvider):
+    def choices(self) -> Tuple[str, ...]:
+        return (
+            "Yes.",
+            "No.",
+        )

--- a/tests/test_choices.py
+++ b/tests/test_choices.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from sopel_8ball.choices import (AbstractChoiceProvider, Classic, Snarky,
-                                 Spooky, Weeaball)
+                                 Spooky, Weeaball, YesNo)
 
 
 def test_abstract_provider():
@@ -43,4 +43,12 @@ def test_weeaball():
     choices = provider.choices()
 
     assert len(choices) == 23
+    assert provider.query(None, None) in choices
+
+
+def test_yesno():
+    provider = YesNo()
+    choices = provider.choices()
+
+    assert len(choices) == 2
     assert provider.query(None, None) in choices

--- a/tests/test_managers.py
+++ b/tests/test_managers.py
@@ -12,6 +12,7 @@ def test_manager_provider_names():
         'snarky',
         'spooky',
         'weeaball',
+        'yesno',
     )
 
 


### PR DESCRIPTION
Tin. The idea came up on IRC, and I figured I'd just do it.

Note that it is not currently possible to install this plugin from source in a Python 3.12 environment because the older version of `setuptools` tries to use `pkgutil.ImpImporter`. It requires at least version 66:

```diff
diff --git a/pyproject.toml b/pyproject.toml
index 1e980d8..b9eca68 100644
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools~=63.0", "wheel"]
+requires = ["setuptools~=66.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools]
```

~~I am happy to add that into this PR, or make a separate one, if it's convenient for you. 😸~~ Was turned into #9.