### PR TITLE
build: bump setuptools for Python 3.12 compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools~=63.0", "wheel"]
+requires = ["setuptools~=66.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools]


### PR DESCRIPTION
This plugin can fail to install from source (editable) for testing in a Python 3.12 environment, because `setuptools<66` tries to use `pkgutil.ImpImporter`. Bumping the build-system requirement ensures that test installs work on the newer Python release.

I referenced this in #8 but ultimately decided to go ahead and make it a separate PR while awaiting review there. 😸